### PR TITLE
fix: resolve PowerShell install script property access error

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -233,9 +233,9 @@ function Install-RatchetBinary {
         $searchNames = @("ratchet.exe", "ratchet", "ratchet-windows-*.exe")
         
         foreach ($name in $searchNames) {
-            $found = Get-ChildItem -Path $tempDir -Name $name -Recurse -File | Select-Object -First 1
+            $found = Get-ChildItem -Path $tempDir -Filter $name -Recurse -File | Select-Object -First 1
             if ($found) {
-                $binaryPath = Get-ChildItem -Path $tempDir -Name $found -Recurse -File | Select-Object -First 1 -ExpandProperty FullName
+                $binaryPath = $found.FullName
                 break
             }
         }


### PR DESCRIPTION
Fixed Get-ChildItem usage that was incorrectly trying to access FullName property on strings. Changed from -Name parameter (returns strings) to -Filter parameter (returns FileInfo objects) and simplified the binary path extraction logic.

🤖 Generated with [Claude Code](https://claude.ai/code)